### PR TITLE
Switch to AppImage packaging (upstream dropped .deb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Then install proxsign:
 
     $ nix-env -i -f https://github.com/domenkozar/proxsign-nix/tarball/master
 
-### Installing on NixOS
+### Installing on NixOS (classic)
 
 If you are using NixOS you can also add the package to your `configuration.nix`.
 
-To pin to a specific version, pick a commit from the [repository history](https://github.com/domenkozar/proxsign-nix/commits/master)
-and fetch its sha256 hash:
+To pin to a specific version, pick a commit hash from the [repository history](https://github.com/domenkozar/proxsign-nix/commits/master)
+and fetch its sha256:
 
-    $ nix-prefetch-url --unpack https://github.com/domenkozar/proxsign-nix/archive/GIT_COMMIT_HASH.tar.gz
+    $ nix-prefetch-url --unpack https://github.com/domenkozar/proxsign-nix/archive/<git-commit-hash>.tar.gz
 
 Then add it to your `configuration.nix` and rebuild:
 
@@ -32,9 +32,25 @@ Then add it to your `configuration.nix` and rebuild:
 environment.systemPackages = [
   # ProxSign
   (import (builtins.fetchTarball {
-    url = "https://github.com/domenkozar/proxsign-nix/archive/GIT_COMMIT_HASH.tar.gz";
-    sha256 = "sha256 output from nix-prefetch-url above";
+    url = "https://github.com/domenkozar/proxsign-nix/archive/<git-commit-hash>.tar.gz";
+    sha256 = "<output from nix-prefetch-url above>";
   }))
+];
+```
+
+### Installing on NixOS (flakes)
+
+Add to your `flake.nix` inputs:
+
+```nix
+inputs.proxsign.url = "github:domenkozar/proxsign-nix";
+```
+
+Then add the package to your system:
+
+```nix
+environment.systemPackages = [
+  inputs.proxsign.packages.x86_64-linux.proxsign
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Proxsign (for Linux using Nix)
 
-[![Build Status](https://travis-ci.org/domenkozar/proxsign-nix.svg?branch=master)](https://travis-ci.org/domenkozar/proxsign-nix)
-
 This repository contains reproducible installation for proxsign signing component
 required for some Slovenian national infrastructure.
 
-## Installation
+> **Note:** Upstream now distributes proXSign as an AppImage. This package wraps it using
+> `appimageTools` for seamless use on NixOS and other Linux distributions with Nix.
 
+## Installation
 
 First you'll need to install Nix via terminal (works on any Linux distribution):
 
@@ -16,19 +16,24 @@ First you'll need to install Nix via terminal (works on any Linux distribution):
 Then install proxsign:
 
     $ nix-env -i -f https://github.com/domenkozar/proxsign-nix/tarball/master
-    
+
 ### Installing on NixOS
 
-If you are using nixos you can also add package to your nixos configuration.
-To install pacakge in you `system` profile you can add this in
-your `configuration.nix` file and rebuild your system:
+If you are using NixOS you can also add the package to your `configuration.nix`.
+
+To pin to a specific version, pick a commit from the [repository history](https://github.com/domenkozar/proxsign-nix/commits/master)
+and fetch its sha256 hash:
+
+    $ nix-prefetch-url --unpack https://github.com/domenkozar/proxsign-nix/archive/GIT_COMMIT_HASH.tar.gz
+
+Then add it to your `configuration.nix` and rebuild:
 
 ```nix
 environment.systemPackages = [
   # ProxSign
   (import (builtins.fetchTarball {
-    url = "https://github.com/domenkozar/proxsign-nix/archive/cc26bee496facdb61c2cbb2bcfef55e167d4a85b.tar.gz";
-    sha256 = "0smhpz7hw382mlin79v681nws4pna5bdg0w8cjb4iq23frnb5dw6";
+    url = "https://github.com/domenkozar/proxsign-nix/archive/GIT_COMMIT_HASH.tar.gz";
+    sha256 = "sha256 output from nix-prefetch-url above";
   }))
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Then install proxsign:
 
     $ nix-env -i -f https://github.com/domenkozar/proxsign-nix/tarball/master
 
+Or run it directly without installing (requires flakes):
+
+    $ nix run github:domenkozar/proxsign-nix
+
 ### Installing on NixOS (classic)
 
 If you are using NixOS you can also add the package to your `configuration.nix`.

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,12 @@
-let
-  nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/9e86f5f7a19db6da2445f07bafa6694b556f9c6d.tar.gz";
-    sha256 = "sha256:0i2j7bf6jq3s13n12xahramami0n6zn1mksqgi01k7flpgyymcck";
-  };
-  pkgs = import nixpkgs {};
-in
+{ pkgs ? import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/b86751bc4085f48661017fa226dee99fab6c651b.tar.gz";
+    sha256 = "sha256:0z1xwfdy3blm5n06lyabyjhadiy79rbm5z4kf309z85kg65mih3b";
+  }) {}
+}:
 
 pkgs.appimageTools.wrapType2 {
-  name = "proxsign";
+  pname = "proxsign";
+  version = "latest";
   src = pkgs.fetchurl {
     url = "https://public.setcce.si/proxsign/update/linux/SETCCE_proXSign-x86_64.AppImage";
     hash = "sha256-Ixe0XjErci2ID4YUx/zr4pf1XTi3M2n9E/IIh2DPYB8=";

--- a/default.nix
+++ b/default.nix
@@ -1,75 +1,16 @@
-with (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/9e86f5f7a19db6da2445f07bafa6694b556f9c6d.tar.gz";
+let
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/9e86f5f7a19db6da2445f07bafa6694b556f9c6d.tar.gz";
     sha256 = "sha256:0i2j7bf6jq3s13n12xahramami0n6zn1mksqgi01k7flpgyymcck";
-  }) {});
-
-let 
-  oldnixpkgs = (import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/3e1be2206b4c1eb3299fb633b8ce9f5ac1c32898.tar.gz";
-    sha256 = "sha256:11d01fdb4d1avi7564h7w332h3jjjadsqwzfzpyh5z56s6rfksxc";
-  }) {});
-
-in stdenv.mkDerivation rec {
-  pname = "proxsign";
-  version = "2.2.7";
-
-  src = fetchurl {
-    url = "https://proxsign.setcce.si/proxsign/repo/xUbuntu_20.04/amd64/proxsign_2.2.7-1+10.3_amd64.deb";
-    #sha256 = "sha256:1a0p7njy8krf41fpvxvl3qf2ydgsyhcigysyrb9wjd483nryxzaj";
-    sha256 = "sha256:1gc4ikxgy8fa243j6hc4nr7wx8imn256ixks7vb25vnnrii21dij";
   };
+  pkgs = import nixpkgs {};
+in
 
-  nativeBuildInputs = [ dpkg makeWrapper ];
-  unpackPhase = "dpkg -x $src ./";
-
-  installPhase = let
-    env = with xorg; lib.makeLibraryPath [
-      freetype
-      libX11
-      libXrender
-      xercesc
-      zlib
-      pango
-      boost165
-      cairo
-      libtiff
-      libpng
-      podofo
-      nss
-      nss_ldap
-      openssl
-      stdenv.cc.cc
-      qt5.qtbase
-      openldap
-      libunistring
-      oldnixpkgs.libidn
-      nspr
-      libxcb
-      xalanc
-      fontconfig
-      (libjpeg_original.overrideDerivation (p: {
-        name = "libjpeg-8d";
-        src = fetchurl {
-          url = http://www.ijg.org/files/jpegsrc.v8d.tar.gz;
-          sha256 = "1cz0dy05mgxqdgjf52p54yxpyy95rgl30cnazdrfmw7hfca9n0h0";
-        };
-      }))
-    ];
-  in ''
-    mkdir -p $out/{bin,etc,share,lib}
-
-    mv usr/bin/proxsign $out/bin/
-    mv etc/proxsign.ini $out/etc/
-    mv usr/share/{applications,icons} $out/share
-    mv usr/lib/*/libp* $out/lib/
-
-    ln -s ${curl.out}/lib/libcurl.so.4 $out/lib/libcurl-nss.so.4
-
-    patchelf --set-rpath "$out/lib:${env}" \
-      $out/lib/libpxs-podofo.so.0.9.7
-    patchelf --set-rpath "$out/lib:${env}" \
-      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/proxsign
-
-    wrapProgram $out/bin/proxsign --set QT_PLUGIN_PATH ${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}
-  '';
+pkgs.appimageTools.wrapType2 {
+  name = "proxsign";
+  src = pkgs.fetchurl {
+    url = "https://public.setcce.si/proxsign/update/linux/SETCCE_proXSign-x86_64.AppImage";
+    hash = "sha256-Ixe0XjErci2ID4YUx/zr4pf1XTi3M2n9E/IIh2DPYB8=";
+  };
+  extraPkgs = pkgs: [ pkgs.gmp pkgs.curl ];
 }

--- a/default.nix
+++ b/default.nix
@@ -6,9 +6,9 @@
 
 pkgs.appimageTools.wrapType2 {
   pname = "proxsign";
-  version = "latest";
+  version = "2.2.13.38";
   src = pkgs.fetchurl {
-    url = "https://public.setcce.si/proxsign/update/linux/SETCCE_proXSign-x86_64.AppImage";
+    url = "https://public.setcce.si/proxsign/update/linux/SETCCE_proXSign-2.2.13.38-x86_64.AppImage";
     hash = "sha256-Ixe0XjErci2ID4YUx/zr4pf1XTi3M2n9E/IIh2DPYB8=";
   };
   extraPkgs = pkgs: [ pkgs.gmp pkgs.curl ];

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,13 @@
+{
+  description = "proXSign signing component for Slovenian national infrastructure";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.proxsign = import ./default.nix {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    };
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.proxsign;
+  };
+}


### PR DESCRIPTION
## Summary

- Upstream SETCCE now distributes proXSign as an AppImage instead of a .deb package
- Replace the manual `dpkg`/`patchelf`/`makeWrapper` derivation with `appimageTools.wrapType2`
- Add `gmp` and `curl` to `extraPkgs` to satisfy runtime library dependencies

## Test plan

- [ ] `nix-env -i -f .` builds successfully
- [ ] `proxsign` launches and shows the GUI with certificates